### PR TITLE
Fix web UI Docker build and development proxy

### DIFF
--- a/webui/.dockerignore
+++ b/webui/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:20-alpine AS build
 WORKDIR /ui
-COPY package.json ./package.json
-RUN npm install
+# Copy lockfile for reproducible builds
+COPY package.json package-lock.json ./
+RUN npm ci
+# Copy source after installing dependencies to leverage Docker layer cache
 COPY . .
 RUN npm run build
 

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -4,7 +4,13 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:10001',
+        changeOrigin: true
+      }
+    }
   }
 })
 


### PR DESCRIPTION
## Summary
- build the web UI with npm ci and add dockerignore
- proxy `/api` requests to backend in Vite dev server

## Testing
- `go test ./...` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af17b635348326bee89da3f5acdf14