### PR TITLE
feat: enforce sandbox policy for services

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -78,6 +79,11 @@ func main() {
 
 	if _, _, err := runtime.InitSchemaRegistry(ctx, cfg); err != nil {
 		log.Fatalf("api schema registry init: %v", err)
+	}
+
+	sandboxLogger := log.New(os.Stdout, "[API] ", log.LstdFlags)
+	if _, err := runtime.EnsureSandbox(ctx, cfg, "api", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+		log.Fatalf("api sandbox: %v", err)
 	}
 
 	if err := srv.Run(cfg); err != nil {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -82,7 +82,7 @@ func main() {
 	}
 
 	sandboxLogger := log.New(os.Stdout, "[API] ", log.LstdFlags)
-	if _, err := runtime.EnsureSandbox(ctx, cfg, "api", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+	if _, _, err := runtime.EnsureSandbox(ctx, cfg, "api", sandboxLogger, runtime.SandboxRequest{}); err != nil {
 		log.Fatalf("api sandbox: %v", err)
 	}
 

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -33,7 +33,7 @@ func main() {
 	}()
 
 	sandboxLogger := log.New(os.Stdout, "[CRAWLER] ", log.LstdFlags)
-	if _, err := runtime.EnsureSandbox(ctx, cfg, "crawler", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+	if _, _, err := runtime.EnsureSandbox(ctx, cfg, "crawler", sandboxLogger, runtime.SandboxRequest{}); err != nil {
 		log.Fatalf("crawler sandbox: %v", err)
 	}
 

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -32,6 +32,11 @@ func main() {
 		_ = telemetry.Shutdown(shutdownCtx)
 	}()
 
+	sandboxLogger := log.New(os.Stdout, "[CRAWLER] ", log.LstdFlags)
+	if _, err := runtime.EnsureSandbox(ctx, cfg, "crawler", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+		log.Fatalf("crawler sandbox: %v", err)
+	}
+
 	if _, _, err := runtime.InitSchemaRegistry(ctx, cfg); err != nil {
 		log.Fatalf("crawler schema registry init: %v", err)
 	}

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -32,17 +32,14 @@ func main() {
 		_ = telemetry.Shutdown(shutdownCtx)
 	}()
 
-	if _, _, err := runtime.InitSchemaRegistry(ctx, cfg); err != nil {
-		log.Fatalf("executor schema registry init: %v", err)
+	sandboxLogger := log.New(os.Stdout, "[EXECUTOR] ", log.LstdFlags)
+
+	if _, err := runtime.EnsureSandbox(ctx, cfg, "executor", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+		log.Fatalf("executor sandbox: %v", err)
 	}
 
-	policy, err := runtime.LoadSandboxPolicy(cfg)
-	if err != nil {
-		log.Fatalf("executor sandbox policy: %v", err)
-	}
-	enforcer := runtime.NewSandboxEnforcer(policy)
-	if err := enforcer.Validate(ctx, runtime.SandboxRequest{}); err != nil {
-		log.Fatalf("executor sandbox validation failed: %v", err)
+	if _, _, err := runtime.InitSchemaRegistry(ctx, cfg); err != nil {
+		log.Fatalf("executor schema registry init: %v", err)
 	}
 
 	if err := runtime.RunPlaceholder(ctx, "executor"); err != nil {

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	sandboxLogger := log.New(os.Stdout, "[EXECUTOR] ", log.LstdFlags)
 
-	if _, err := runtime.EnsureSandbox(ctx, cfg, "executor", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+	if _, _, err := runtime.EnsureSandbox(ctx, cfg, "executor", sandboxLogger, runtime.SandboxRequest{}); err != nil {
 		log.Fatalf("executor sandbox: %v", err)
 	}
 

--- a/cmd/memory/main.go
+++ b/cmd/memory/main.go
@@ -33,7 +33,7 @@ func main() {
 	}()
 
 	sandboxLogger := log.New(os.Stdout, "[MEMORY] ", log.LstdFlags)
-	if _, err := runtime.EnsureSandbox(ctx, cfg, "memory", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+	if _, _, err := runtime.EnsureSandbox(ctx, cfg, "memory", sandboxLogger, runtime.SandboxRequest{}); err != nil {
 		log.Fatalf("memory sandbox: %v", err)
 	}
 

--- a/cmd/memory/main.go
+++ b/cmd/memory/main.go
@@ -32,6 +32,11 @@ func main() {
 		_ = telemetry.Shutdown(shutdownCtx)
 	}()
 
+	sandboxLogger := log.New(os.Stdout, "[MEMORY] ", log.LstdFlags)
+	if _, err := runtime.EnsureSandbox(ctx, cfg, "memory", sandboxLogger, runtime.SandboxRequest{}); err != nil {
+		log.Fatalf("memory sandbox: %v", err)
+	}
+
 	if _, _, err := runtime.InitSchemaRegistry(ctx, cfg); err != nil {
 		log.Fatalf("memory schema registry init: %v", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	logger := log.New(os.Stdout, "[WORKER] ", log.LstdFlags)
 
-	if _, err := runtime.EnsureSandbox(ctx, cfg, "worker", logger, runtime.SandboxRequest{}); err != nil {
+	if _, _, err := runtime.EnsureSandbox(ctx, cfg, "worker", logger, runtime.SandboxRequest{}); err != nil {
 		log.Fatalf("worker sandbox: %v", err)
 	}
 

--- a/internal/helpers/TASKS.md
+++ b/internal/helpers/TASKS.md
@@ -2,7 +2,7 @@
 
 Roadmap references: `Ix.Ey` = Initiative/Epic from `tasks.md`.
 
-- [ ] [I4.E4] Provide utility functions for sanitising HTML and preventing XSS in generated content.
+- [x] [I4.E4] Provide utility functions for sanitising HTML and preventing XSS in generated content.
 - [ ] [I5.E2] Implement URL canonicalisation helpers (protocol normalisation, UTM stripping) and expose fingerprint utilities.
 - [ ] [I5.E1] Supply semantic diff tooling (content hash comparison, last_seen_at checks) for crawler incremental fetching.
 - [ ] [I6.E1] Offer citation formatting helpers to include source IDs/snippets consistently.

--- a/internal/helpers/sanitize.go
+++ b/internal/helpers/sanitize.go
@@ -1,0 +1,81 @@
+package helpers
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/microcosm-cc/bluemonday"
+)
+
+var (
+	strictPolicyOnce sync.Once
+	strictPolicy     *bluemonday.Policy
+
+	richTextPolicyOnce sync.Once
+	richTextPolicy     *bluemonday.Policy
+)
+
+// StrictHTMLPolicy returns a singleton bluemonday policy that strips every HTML
+// element and attribute. It is useful when the output should be treated as
+// plain text while ensuring that script/style injections are removed.
+func StrictHTMLPolicy() *bluemonday.Policy {
+	strictPolicyOnce.Do(func() {
+		strictPolicy = bluemonday.StrictPolicy()
+	})
+	return strictPolicy
+}
+
+// RichTextHTMLPolicy returns a policy that allows a small, curated subset of
+// HTML formatting tags (paragraphs, emphasis, lists, code blocks, links) while
+// ensuring dangerous attributes and JavaScript URLs are removed. The policy is
+// cached to avoid repeated allocations when sanitising many fragments.
+func RichTextHTMLPolicy() *bluemonday.Policy {
+	richTextPolicyOnce.Do(func() {
+		policy := bluemonday.UGCPolicy()
+		policy.AllowElements("figure", "figcaption")
+		policy.AllowAttrs("class").OnElements("code", "pre", "figure")
+		policy.AllowURLSchemes("http", "https", "mailto")
+		policy.AllowRelativeURLs(true)
+		policy.RequireParseableURLs(true)
+		policy.AddTargetBlankToFullyQualifiedLinks(true)
+		richTextPolicy = policy
+	})
+	return richTextPolicy
+}
+
+// SanitizeHTMLStrict removes every HTML tag from s while stripping leading and
+// trailing whitespace. It provides a safe plain-text representation of the
+// value.
+func SanitizeHTMLStrict(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	return strings.TrimSpace(StrictHTMLPolicy().Sanitize(s))
+}
+
+// SanitizeHTMLRichText cleans s using RichTextHTMLPolicy while preserving a
+// limited set of formatting tags. Event handlers, inline scripts and unsafe
+// URLs are removed.
+func SanitizeHTMLRichText(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	return strings.TrimSpace(RichTextHTMLPolicy().Sanitize(s))
+}
+
+// StripUnsafeHTML normalises the provided HTML string by first attempting the
+// rich-text sanitisation. If no HTML tags survive the clean-up, it falls back
+// to the strict policy so callers receive a plain-text value. It is handy for
+// user-supplied fragments that may occasionally include formatting.
+func StripUnsafeHTML(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return ""
+	}
+	sanitized := SanitizeHTMLRichText(s)
+	if strings.ContainsAny(sanitized, "<>/") {
+		return sanitized
+	}
+	return SanitizeHTMLStrict(s)
+}

--- a/internal/helpers/sanitize_test.go
+++ b/internal/helpers/sanitize_test.go
@@ -1,0 +1,39 @@
+package helpers
+
+import "testing"
+
+func TestSanitizeHTMLStrict_RemovesTagsAndScripts(t *testing.T) {
+	input := `<p>Hello <strong>world</strong><script>alert('x')</script></p>`
+	got := SanitizeHTMLStrict(input)
+	want := "Hello world"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSanitizeHTMLRichText_PreservesFormatting(t *testing.T) {
+	input := `<p onclick="evil()">Hi <strong>there</strong> <a href="javascript:alert(1)">click</a></p>`
+	got := SanitizeHTMLRichText(input)
+	want := `<p>Hi <strong>there</strong> click</p>`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestStripUnsafeHTML_FallsBackToStrictWhenNoMarkup(t *testing.T) {
+	input := `Plain text with <b>fake</b> tag`
+	got := StripUnsafeHTML(input)
+	want := "Plain text with <b>fake</b> tag"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestStripUnsafeHTML_KeepsRichMarkupWhenAllowed(t *testing.T) {
+	input := `<p>Paragraph with <em>emphasis</em> and <a href="https://example.com">link</a></p>`
+	got := StripUnsafeHTML(input)
+	want := `<p>Paragraph with <em>emphasis</em> and <a href="https://example.com" rel="nofollow noopener" target="_blank">link</a></p>`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/internal/runtime/TASKS.md
+++ b/internal/runtime/TASKS.md
@@ -2,7 +2,7 @@
 
 Roadmap references: `Ix.Ey` = Initiative/Epic from `tasks.md`, `FG` = Feasibility Gate.
 
-- [ ] [I1.E4] Finish sandbox policy enforcement ensuring every service reports sandbox=true and aborts on violations.
+- [x] [I1.E4] Finish sandbox policy enforcement ensuring every service reports sandbox=true and aborts on violations.
 - [ ] [I2.E1] Centralise capability registry bootstrap and manifest signature validation for all binaries.
 - [ ] [I4.E1] Provide shared sandbox adapters (Docker/NSJail) with resource defaults used by executor services.
 - [ ] [I6.E3] Offer helpers to sign run manifests and verify hashes prior to persistence/export.

--- a/internal/runtime/sandbox.go
+++ b/internal/runtime/sandbox.go
@@ -1,108 +1,150 @@
 package runtime
 
 import (
-    "context"
-    "fmt"
-    "os"
-    "time"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
 
-    "github.com/mohammad-safakhou/newser/config"
-    "gopkg.in/yaml.v3"
+	"github.com/mohammad-safakhou/newser/config"
+	"gopkg.in/yaml.v3"
 )
 
 // SandboxPolicy represents runtime sandbox settings.
 type SandboxPolicy struct {
-    Provider string   `yaml:"provider"`
-    Image    string   `yaml:"image"`
-    CPU      float64  `yaml:"cpu"`
-    Memory   string   `yaml:"memory"`
-    Timeout  string   `yaml:"timeout"`
-    Network  struct {
-        Enabled   bool     `yaml:"enabled"`
-        Allowlist []string `yaml:"allowlist"`
-    } `yaml:"network"`
-    EnvAllowlist   []string `yaml:"env_allowlist"`
-    MountReadOnly  []string `yaml:"mount_readonly"`
+	Provider string  `yaml:"provider"`
+	Image    string  `yaml:"image"`
+	CPU      float64 `yaml:"cpu"`
+	Memory   string  `yaml:"memory"`
+	Timeout  string  `yaml:"timeout"`
+	Network  struct {
+		Enabled   bool     `yaml:"enabled"`
+		Allowlist []string `yaml:"allowlist"`
+	} `yaml:"network"`
+	EnvAllowlist  []string `yaml:"env_allowlist"`
+	MountReadOnly []string `yaml:"mount_readonly"`
 }
 
 // LoadSandboxPolicy reads policy from config.Security.PolicyFile.
 func LoadSandboxPolicy(cfg *config.Config) (*SandboxPolicy, error) {
-    if cfg == nil {
-        return nil, fmt.Errorf("config is nil")
-    }
-    policyPath := cfg.Security.PolicyFile
-    if policyPath == "" {
-        return nil, fmt.Errorf("security.policy_file not configured")
-    }
-    data, err := os.ReadFile(policyPath)
-    if err != nil {
-        return nil, fmt.Errorf("read policy: %w", err)
-    }
-    var policy struct {
-        Sandbox SandboxPolicy `yaml:"sandbox"`
-    }
-    if err := yaml.Unmarshal(data, &policy); err != nil {
-        return nil, fmt.Errorf("parse policy: %w", err)
-    }
-    if policy.Sandbox.Provider == "" {
-        policy.Sandbox.Provider = cfg.Security.SandboxProvider
-    }
-    if policy.Sandbox.Timeout == "" {
-        policy.Sandbox.Timeout = cfg.Security.DefaultTimeout.String()
-    }
-    if policy.Sandbox.CPU == 0 {
-        policy.Sandbox.CPU = cfg.Security.DefaultCPU
-    }
-    if policy.Sandbox.Memory == "" {
-        policy.Sandbox.Memory = cfg.Security.DefaultMemory
-    }
-    return &policy.Sandbox, nil
+	if cfg == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	policyPath := cfg.Security.PolicyFile
+	if policyPath == "" {
+		return nil, fmt.Errorf("security.policy_file not configured")
+	}
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read policy: %w", err)
+	}
+	var policy struct {
+		Sandbox SandboxPolicy `yaml:"sandbox"`
+	}
+	if err := yaml.Unmarshal(data, &policy); err != nil {
+		return nil, fmt.Errorf("parse policy: %w", err)
+	}
+	if policy.Sandbox.Provider == "" {
+		policy.Sandbox.Provider = cfg.Security.SandboxProvider
+	}
+	if policy.Sandbox.Timeout == "" {
+		policy.Sandbox.Timeout = cfg.Security.DefaultTimeout.String()
+	}
+	if policy.Sandbox.CPU == 0 {
+		policy.Sandbox.CPU = cfg.Security.DefaultCPU
+	}
+	if policy.Sandbox.Memory == "" {
+		policy.Sandbox.Memory = cfg.Security.DefaultMemory
+	}
+	if policy.Sandbox.Provider == "" {
+		return nil, fmt.Errorf("sandbox provider missing; set security.sandbox_provider or sandbox.provider in policy")
+	}
+	return &policy.Sandbox, nil
 }
 
 // SandboxEnforcer performs policy validation prior to execution.
 type SandboxEnforcer struct {
-    policy *SandboxPolicy
+	policy *SandboxPolicy
 }
 
 func NewSandboxEnforcer(policy *SandboxPolicy) *SandboxEnforcer {
-    return &SandboxEnforcer{policy: policy}
+	return &SandboxEnforcer{policy: policy}
 }
 
 // Validate ensures settings meet policy requirements.
 func (e *SandboxEnforcer) Validate(ctx context.Context, req SandboxRequest) error {
-    if e == nil || e.policy == nil {
-        return nil
-    }
-    if req.Provider != "" && req.Provider != e.policy.Provider {
-        return fmt.Errorf("provider %s not allowed (configured %s)", req.Provider, e.policy.Provider)
-    }
-    if req.CPU <= 0 {
-        req.CPU = e.policy.CPU
-    }
-    if req.CPU > e.policy.CPU {
-        return fmt.Errorf("cpu %.2f exceeds policy %.2f", req.CPU, e.policy.CPU)
-    }
-    if req.Timeout <= 0 {
-        // Use policy timeout
-        if d, err := time.ParseDuration(e.policy.Timeout); err == nil {
-            req.Timeout = d
-        }
-    }
-    if req.Timeout > 0 {
-        if d, err := time.ParseDuration(e.policy.Timeout); err == nil && req.Timeout > d {
-            return fmt.Errorf("timeout %s exceeds policy %s", req.Timeout, d)
-        }
-    }
-    if !e.policy.Network.Enabled && req.NetworkEnabled {
-        return fmt.Errorf("network access disabled by policy")
-    }
-    return nil
+	if e == nil || e.policy == nil {
+		return nil
+	}
+	if req.Provider != "" && req.Provider != e.policy.Provider {
+		return fmt.Errorf("provider %s not allowed (configured %s)", req.Provider, e.policy.Provider)
+	}
+	if req.Provider == "" && e.policy.Provider != "" {
+		req.Provider = e.policy.Provider
+	}
+	if req.CPU <= 0 {
+		req.CPU = e.policy.CPU
+	}
+	if req.CPU > e.policy.CPU {
+		return fmt.Errorf("cpu %.2f exceeds policy %.2f", req.CPU, e.policy.CPU)
+	}
+	if req.Timeout <= 0 {
+		// Use policy timeout
+		if d, err := time.ParseDuration(e.policy.Timeout); err == nil {
+			req.Timeout = d
+		}
+	}
+	if req.Timeout > 0 {
+		if d, err := time.ParseDuration(e.policy.Timeout); err == nil && req.Timeout > d {
+			return fmt.Errorf("timeout %s exceeds policy %s", req.Timeout, d)
+		}
+	}
+	if !e.policy.Network.Enabled && req.NetworkEnabled {
+		return fmt.Errorf("network access disabled by policy")
+	}
+	return nil
 }
 
 // SandboxRequest describes an execution request for validation.
 type SandboxRequest struct {
-    Provider       string
-    CPU            float64
-    Timeout        time.Duration
-    NetworkEnabled bool
+	Provider       string
+	CPU            float64
+	Timeout        time.Duration
+	NetworkEnabled bool
+}
+
+// Policy returns the underlying policy, useful for diagnostics and logging.
+func (e *SandboxEnforcer) Policy() *SandboxPolicy {
+	if e == nil {
+		return nil
+	}
+	return e.policy
+}
+
+// EnsureSandbox loads the sandbox policy, validates the provided request against
+// the policy and logs a standard "sandbox=true" message for observability.
+func EnsureSandbox(ctx context.Context, cfg *config.Config, service string, logger *log.Logger, req SandboxRequest) (*SandboxEnforcer, error) {
+	policy, err := LoadSandboxPolicy(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	enforcer := NewSandboxEnforcer(policy)
+	if err := enforcer.Validate(ctx, req); err != nil {
+		return nil, err
+	}
+
+	if logger == nil {
+		prefix := strings.TrimSpace(service)
+		if prefix == "" {
+			prefix = "service"
+		}
+		logger = log.New(os.Stdout, fmt.Sprintf("[%s] ", strings.ToUpper(prefix)), log.LstdFlags)
+	}
+
+	logger.Printf("sandbox=true provider=%s cpu=%.2f memory=%s timeout=%s network_enabled=%t allowlist=%d", policy.Provider, policy.CPU, policy.Memory, policy.Timeout, policy.Network.Enabled, len(policy.Network.Allowlist))
+
+	return enforcer, nil
 }

--- a/internal/runtime/sandbox_test.go
+++ b/internal/runtime/sandbox_test.go
@@ -1,0 +1,89 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mohammad-safakhou/newser/config"
+)
+
+func writePolicy(t *testing.T, dir, provider string, network bool) string {
+	t.Helper()
+	path := filepath.Join(dir, "policy.yaml")
+	contents := []byte("sandbox:\n  provider: " + provider + "\n  cpu: 1\n  memory: 512Mi\n  timeout: 60s\n  network:\n    enabled: " + boolToString(network) + "\n    allowlist: []\n")
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	return path
+}
+
+func boolToString(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+func TestEnsureSandboxReportsStatus(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	policyPath := writePolicy(t, dir, "docker", false)
+	cfg := &config.Config{Security: config.SecurityConfig{PolicyFile: policyPath, SandboxProvider: "docker", DefaultCPU: 1, DefaultMemory: "512Mi", DefaultTimeout: 60 * time.Second}}
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	enforcer, err := EnsureSandbox(context.Background(), cfg, "worker", logger, SandboxRequest{})
+	if err != nil {
+		t.Fatalf("EnsureSandbox error: %v", err)
+	}
+	if enforcer == nil {
+		t.Fatal("expected enforcer")
+	}
+	if got := buf.String(); got == "" {
+		t.Fatal("expected log output, got empty string")
+	} else {
+		if !bytes.Contains(buf.Bytes(), []byte("sandbox=true")) {
+			t.Fatalf("expected sandbox=true in log, got %q", got)
+		}
+		if !bytes.Contains(buf.Bytes(), []byte("provider=docker")) {
+			t.Fatalf("expected provider in log, got %q", got)
+		}
+	}
+}
+
+func TestEnsureSandboxViolatesPolicy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	policyPath := writePolicy(t, dir, "docker", false)
+	cfg := &config.Config{Security: config.SecurityConfig{PolicyFile: policyPath, SandboxProvider: "docker", DefaultCPU: 1, DefaultMemory: "512Mi", DefaultTimeout: 60 * time.Second}}
+
+	_, err := EnsureSandbox(context.Background(), cfg, "crawler", nil, SandboxRequest{NetworkEnabled: true})
+	if err == nil {
+		t.Fatal("expected error when requesting network access")
+	}
+}
+
+func TestEnsureSandboxMissingProvider(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Write policy without provider to ensure config fallback is required.
+	path := filepath.Join(dir, "policy.yaml")
+	contents := []byte("sandbox:\n  cpu: 1\n  memory: 512Mi\n  timeout: 60s\n  network:\n    enabled: false\n    allowlist: []\n")
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	cfg := &config.Config{Security: config.SecurityConfig{PolicyFile: path, SandboxProvider: "", DefaultCPU: 1, DefaultMemory: "512Mi", DefaultTimeout: 60 * time.Second}}
+
+	if _, err := EnsureSandbox(context.Background(), cfg, "api", nil, SandboxRequest{}); err == nil {
+		t.Fatal("expected error due to missing sandbox provider")
+	}
+}

--- a/internal/server/runs.go
+++ b/internal/server/runs.go
@@ -14,12 +14,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/labstack/echo/v4"
-	"github.com/microcosm-cc/bluemonday"
-	"github.com/mohammad-safakhou/newser/config"
-	core "github.com/mohammad-safakhou/newser/internal/agent/core"
-	"github.com/mohammad-safakhou/newser/internal/budget"
-	"github.com/mohammad-safakhou/newser/internal/helpers"
+        "github.com/labstack/echo/v4"
+        "github.com/mohammad-safakhou/newser/config"
+        core "github.com/mohammad-safakhou/newser/internal/agent/core"
+        "github.com/mohammad-safakhou/newser/internal/budget"
+        "github.com/mohammad-safakhou/newser/internal/helpers"
 	"github.com/mohammad-safakhou/newser/internal/manifest"
 	"github.com/mohammad-safakhou/newser/internal/memory/semantic"
 	"github.com/mohammad-safakhou/newser/internal/planner"
@@ -112,8 +111,7 @@ type runStreamPayload struct {
 }
 
 var (
-	htmlSanitizer = bluemonday.StrictPolicy()
-	runsTracer    = otel.Tracer("newser/internal/server/runs")
+        runsTracer = otel.Tracer("newser/internal/server/runs")
 )
 
 func NewRunsHandler(cfg *config.Config, store *store.Store, orch *core.Orchestrator, provider core.LLMProvider, ingest *semantic.Ingestor) *RunsHandler {
@@ -1883,11 +1881,11 @@ func safeString(v interface{}) string {
 	if v == nil {
 		return ""
 	}
-	if s, ok := v.(string); ok {
-		return strings.TrimSpace(htmlSanitizer.Sanitize(s))
-	}
-	b, _ := json.Marshal(v)
-	return strings.TrimSpace(htmlSanitizer.Sanitize(string(b)))
+        if s, ok := v.(string); ok {
+                return helpers.SanitizeHTMLStrict(s)
+        }
+        b, _ := json.Marshal(v)
+        return helpers.SanitizeHTMLStrict(string(b))
 }
 func safeFloat(v interface{}) float64 {
 	switch t := v.(type) {


### PR DESCRIPTION
## Summary
- add a shared runtime.EnsureSandbox helper that validates policy requirements and emits a standard sandbox=true log
- invoke sandbox enforcement in the api, worker, executor, crawler, and memory services and mark the runtime task complete
- cover the helper with focused unit tests exercising happy-path logging and failure conditions

## Testing
- go test ./internal/runtime -v

------
https://chatgpt.com/codex/tasks/task_e_68e3bf543c948333ba94b63425c7c207